### PR TITLE
Bump to mamba_gator v6.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mamba_gator" %}
-{% set version = "6.0.1" %}
+{% set version = "6.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0bda2945e733d8633296bdc79a76487f44017c5b3089f61bf4098048bafe1b7b
+  sha256: faa5ff346346a4895ee3c76a5b820d42a42a40cf332a3ddc6f1c6c6a56372242
 
 build:
   skip: true  # [py<38]


### PR DESCRIPTION
## mamba_gator 6.0.2

**Destination channel:** defaults

### Links
- [Upstream repository](https://github.com/mamba-org/gator)
- [Upstream changelog/diff](https://github.com/mamba-org/gator/compare/v6.0.1...v6.0.2)

### Explanation of changes:
- Updated mamba_gator to version 6.0.2
- Updated SHA256 hash for the new version
